### PR TITLE
Fix autoExecute failed UPDATE if placeholders presents in WHERE (bug #21217)

### DIFF
--- a/DB/common.php
+++ b/DB/common.php
@@ -885,6 +885,9 @@ class DB_common extends PEAR
     function autoExecute($table, $fields_values, $mode = DB_AUTOQUERY_INSERT,
                          $where = false)
     {
+        if ($where) {
+            $where = strtr($where, array('?' => '\?', '!' => '\!', '&' => '\&',));
+        }
         $sth = $this->autoPrepare($table, array_keys($fields_values), $mode,
                                   $where);
         if (DB::isError($sth)) {


### PR DESCRIPTION
autoExecute failed UPDATE if placeholders presents in WHERE

See bug #21217: https://pear.php.net/bugs/bug.php?id=21217

Description:
------------
If you call autoExecute() and in WHERE present any of '!?&' query simple fails. Does not matter where these symbols appear - inside string literal or in query (for example  'a != b').
This happens because inside autoExecute() where used for catch placeholders. For example you send to autoExecute() array with $data of 3 items and $where with 'a != b'. On autoPrepare() inside autoExecute() will be collected FOUR placeholders. 3 from $data and '!' inside $where as 4 placeholder.
After that will be called execute() with $data array. But it have only 3 values. It cause error because parsed statement required 4 values for 4 placeholders.

Solution: make replace in $where before send it to autoPrepare() inside autoExecute():

```
if ($where) {
    $where = strtr($where, array('?' => '\?', '!' => '\!', '&' => '\&',));
}
```

Test script:
---------------
```
$data = array('a' => 'a', 'b' => 'b', 'c' => 'c');
$ret = $db->autoExecute('table', $data, DB_AUTOQUERY_UPDATE, 'a != b');
var_dump($ret);
```

Expected result:
----------------
`DB_OK`

Actual result:
--------------
`DB_ERROR: DB_ERROR_MISMATCH raised from executeEmulateQuery()`