### PR TITLE
Fixes an issue with oci8 driver, which causes getOne, getRow, getCol,…

### DIFF
--- a/DB/oci8.php
+++ b/DB/oci8.php
@@ -446,9 +446,6 @@ class DB_oci8 extends DB_common
         if (!is_resource($stmt)) {
             return false;
         }
-        if ($free_resource) {
-            @ocifreestatement($stmt);
-        }
         if (isset($this->prepare_types[(int)$stmt])) {
             unset($this->prepare_types[(int)$stmt]);
             unset($this->manip_query[(int)$stmt]);


### PR DESCRIPTION
… getAssoc, getAll to fail. Removed unnecessary call to ocifreestatement which is preventing ocifetchinto from working inside these methods. The statement is already freed in freeResult method after the request is completed.