### PR TITLE
each() deprecated in PHP 7.2

### DIFF
--- a/DB/storage.php
+++ b/DB/storage.php
@@ -336,7 +336,7 @@ class DB_storage extends PEAR
         }
         reset($rowdata);
         $found_keycolumn = false;
-        while (list($key, $value) = each($rowdata)) {
+        foreach($rowdata as $key => $value) {
             if ($key == $this->_keycolumn) {
                 $found_keycolumn = true;
             }

--- a/DB/storage.php
+++ b/DB/storage.php
@@ -336,7 +336,7 @@ class DB_storage extends PEAR
         }
         reset($rowdata);
         $found_keycolumn = false;
-        foreach($rowdata as $key => $value) {
+        foreach ($rowdata as $key => $value) {
             if ($key == $this->_keycolumn) {
                 $found_keycolumn = true;
             }


### PR DESCRIPTION
Not sure if there is any interest in fixing this, but each() has been deprecated in PHP 7.2, it appears to be commented out anyways.