### PR TITLE
fix prototypes for PHP 8

### DIFF
--- a/DB/dbase.php
+++ b/DB/dbase.php
@@ -269,7 +269,7 @@ class DB_dbase extends DB_common
     // }}}
     // {{{ &query()
 
-    function &query($query = null)
+    function &query($query = null, $params = array())
     {
         // emulate result resources
         $this->res_row[(int)$this->result] = 0;

--- a/tests/db_error.phpt
+++ b/tests/db_error.phpt
@@ -7,7 +7,7 @@ DB::DB_Error
 require_once dirname(__FILE__) . '/include.inc';
 require_once 'DB.php';
 
-function test_error_handler($errno, $errmsg, $file, $line, $vars) {
+function test_error_handler($errno, $errmsg, $file, $line, $vars=null) {
     if (defined('E_STRICT')) {
         if ($errno & E_STRICT
             && (error_reporting() & E_STRICT) != E_STRICT) {

--- a/tests/db_error2.phpt
+++ b/tests/db_error2.phpt
@@ -21,7 +21,7 @@ class myclass {
           . strtolower($obj->toString()) . "\n";
     }
 }
-function test_error_handler($errno, $errmsg, $file, $line, $vars) {
+function test_error_handler($errno, $errmsg, $file, $line, $vars=null) {
     if (defined('E_STRICT')) {
         if ($errno & E_STRICT
             && (error_reporting() & E_STRICT) != E_STRICT) {


### PR DESCRIPTION
Test suite fails with 8.0.9
```
Running 5 tests
FAIL DB::DB_Error[db_error.phpt]
FAIL DB::Error 2[db_error2.phpt]
FAIL DB::factory[db_factory.phpt]
PASS DB::isManip[db_ismanip.phpt]
PASS DB::parseDSN[db_parsedsn.phpt]
wrote log to "/builddir/build/BUILD/php-pear-DB-1.11.0/DB-1.11.0/tests/run-tests.log"
TOTAL TIME: 00:00
2 PASSED TESTS
0 SKIPPED TESTS
3 FAILED TESTS:

```

With this patch
```
PASS DB::DB_Error[db_error.phpt]
PASS DB::Error 2[db_error2.phpt]
PASS DB::factory[db_factory.phpt]
PASS DB::isManip[db_ismanip.phpt]
PASS DB::parseDSN[db_parsedsn.phpt]
TOTAL TIME: 00:01
5 PASSED TESTS
0 SKIPPED TESTS
```
