### PR TITLE
PHP8.2 Support DB_DataObject by ensuring no dynamic property  is created

### DIFF
--- a/DB/common.php
+++ b/DB/common.php
@@ -136,6 +136,8 @@ class DB_common extends PEAR
      */
     var $_next_query_manip = false;
 
+    var $num_rows = 0;
+
 
     // }}}
     // {{{ DB_common


### PR DESCRIPTION
If you look at http://svn.php.net/viewvc/pear/packages/DB_DataObject/trunk/DB/DataObject.php?view=markup&pathrev=339312 at Line 4778 you will find it adds in a property num_rows into the DB_Mysqli or any DB_x classes so this fixes it in php8.2 as creation of dynamic properties is deprecated in php8.2

ping @ashnazg 