### PR TITLE
DB::apiVersion() should be declared as static

### DIFF
--- a/DB.php
+++ b/DB.php
@@ -589,7 +589,7 @@ class DB
      *
      * @return string  the DB API version number
      */
-    function apiVersion()
+    public static function apiVersion()
     {
         return '@package_version@';
     }


### PR DESCRIPTION
The DB class is designed to be called statically, but for some reason the apiVersion() method is not declared as such.

This will result in deprecation notices on PHP 7 and fatal errors on PHP 8, where it is no longer permitted to call non-static functions statically.

Note that this change will not break any misbehaving code that is instantiating the DB class in order to call this method - it is quite acceptable to call a static function on an object instance.