### PR TITLE
Minimal fix for sqlite3

### DIFF
--- a/tests/driver/setup.inc
+++ b/tests/driver/setup.inc
@@ -112,10 +112,10 @@ $dsns = array(
     // 'db2'      => 'odbc(db2)://db2inst1:XXXX@/SAMPLE',
     // 'pgsql'    => 'pgsql://postgres@localhost/test',
     // 'sqlite'   => 'sqlite://dummy:@localhost/' . getcwd() . DIRECTORY_SEPARATOR . 'test.db?mode=0644',
-    // 'sqlite3'  => 'sqlite://dummy:@localhost/' . getcwd() . DIRECTORY_SEPARATOR . 'test.db?mode=0644',
+    // 'sqlite3'  => 'sqlite3://dummy:@localhost/' . getcwd() . DIRECTORY_SEPARATOR . 'test.db?mode=0644',
 );
 
-if (getenv('MYSQL_TEST_USER') !== '') {
+if (getenv('MYSQL_TEST_USER')) {
     $dsns['mysqli'] = array(
         'phptype' => 'mysqli',
         'username' => getenv('MYSQL_TEST_USER'),


### PR DESCRIPTION
This allow to run test suite with sqlite3 driver

BTW test suite is not ready, lot of failures, some related to resource-to-object conversion

```
Running 19 tests
FAIL [ 1/19] DB_driver::connect[driver/01connect.phpt]
PASS [ 2/19] DB_driver::fetch[driver/02fetch.phpt]
FAIL [ 3/19] DB_driver::simpleQuery[driver/03simplequery.phpt]
PASS [ 4/19] DB_driver::numCols[driver/04numcols.phpt]
FAIL [ 5/19] DB_driver::sequences[driver/05sequences.phpt]
PASS [ 6/19] DB_driver::prepare/execute[driver/06prepexec.phpt]
FAIL [ 7/19] DB_driver::affectedRows[driver/08affectedrows.phpt]
PASS [ 8/19] DB_driver::numRows[driver/09numrows.phpt]
FAIL [ 9/19] DB_driver::error mapping[driver/10errormap.phpt]
SKIP DB_driver::transaction test[driver/11transactions.phpt](reason: this driver does not support transactions)
FAIL [11/19] DB_driver::row limit[driver/13limit.phpt]
PASS [12/19] DB_driver::fetchmode object[driver/14fetchmode_object.phpt]
FAIL [13/19] DB_driver::quote[driver/15quote.phpt]
FAIL [14/19] DB_driver::tableInfo[driver/16tableinfo.phpt]
PASS [15/19] DB_driver::query[driver/17query.phpt]
FAIL [16/19] DB_driver::get[driver/18get.phpt]
FAIL [17/19] DB_driver::getListOf[driver/19getlistof.phpt]
PASS [18/19] DB_driver::locale[driver/20locale.phpt]
FAIL [19/19] DB_driver::freeResult[driver/21freeResult.phpt]
```