### PR TITLE
fix fetch args

### DIFF
--- a/DB/oci8.php
+++ b/DB/oci8.php
@@ -383,14 +383,16 @@ class DB_oci8 extends DB_common
             return $this->raiseError(DB_ERROR_NOT_CAPABLE);
         }
         if ($fetchmode & DB_FETCHMODE_ASSOC) {
-            $moredata = @oci_fetch_array($result,$arr,OCI_ASSOC+OCI_RETURN_NULLS+OCI_RETURN_LOBS);
+            $arr = @oci_fetch_array($result,OCI_ASSOC+OCI_RETURN_NULLS+OCI_RETURN_LOBS);
+            $moredata = count($arr);
             if ($this->options['portability'] & DB_PORTABILITY_LOWERCASE &&
                 $moredata)
             {
                 $arr = array_change_key_case($arr, CASE_LOWER);
             }
         } else {
-            $moredata = oci_fetch_array($result,$arr,OCI_RETURN_NULLS+OCI_RETURN_LOBS);
+            $arr = @oci_fetch_array($result,OCI_ASSOC+OCI_RETURN_NULLS+OCI_RETURN_LOBS);
+            $moredata = count($arr);
         }
         if (!$moredata) {
             return null;

--- a/DB/oci8.php
+++ b/DB/oci8.php
@@ -384,7 +384,11 @@ class DB_oci8 extends DB_common
         }
         if ($fetchmode & DB_FETCHMODE_ASSOC) {
             $arr = @oci_fetch_array($result,OCI_ASSOC+OCI_RETURN_NULLS+OCI_RETURN_LOBS);
-            $moredata = count($arr);
+            if (is_array($arr)) {
+                $moredata = count($arr);
+            } else {
+                $moredata = false;
+            }
             if ($this->options['portability'] & DB_PORTABILITY_LOWERCASE &&
                 $moredata)
             {
@@ -392,7 +396,11 @@ class DB_oci8 extends DB_common
             }
         } else {
             $arr = @oci_fetch_array($result,OCI_ASSOC+OCI_RETURN_NULLS+OCI_RETURN_LOBS);
-            $moredata = count($arr);
+            if (is_array($arr)) {
+                $moredata = count($arr);
+            } else {
+                $moredata = false;
+            }
         }
         if (!$moredata) {
             return null;


### PR DESCRIPTION
Issue #33 .  This fixes the args for `oci_fetch_array`.  I tried to keep the same `$moredata` logic, based on (what I _think_ is) original `ocifetchinto` return behavior of integer of rows fetched.

@schengawegga , I'll need you to test this since I don't have the right environment.