### PR TITLE
Errors raised in DB_storage::toString() if there are multi-column keys, on PHP >= 7

### DIFF
--- a/DB/storage.php
+++ b/DB/storage.php
@@ -251,7 +251,7 @@ class DB_storage extends PEAR
                     if ($i > 0) {
                         $info .= ",";
                     }
-                    $info .= $this->$keyname[$i];
+                    $info .= $this->{$keyname[$i]};
                 }
                 $info .= ")";
             } else {


### PR DESCRIPTION
As reported by PHPCompatibility:

```
FILE: ./DB/storage.php
-----------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
-----------------------------------------------------------------------------
 254 | ERROR | Indirect access to variables, properties and methods will be
     |       | evaluated strictly in left-to-right order since PHP 7.0. Use
     |       | curly braces to remove ambiguity.
-----------------------------------------------------------------------------
```

On PHP 5 this code correctly retrieves the class property whose name is held in `$keyname[$i]`.

As of PHP 7 it raises a number of PHP errors.  They are notices on PHP 7 and warnings on PHP 8:

```
Warning: Array to string conversion in DB/storage.php on line 254

Warning: Undefined property: DB_storage::$Array in DB/storage.php on line 254

Warning: Trying to access array offset on null in DB/storage.php on line 254
```

Adding explicit braces resolves this issue and restores the intended behaviour across all PHP versions.