### PR TITLE
Fix PHP8.1 change from pgsql result resource to PgSql\Result.

### DIFF
--- a/DB/dbase.php
+++ b/DB/dbase.php
@@ -302,7 +302,7 @@ class DB_dbase extends DB_common
     function fetchInto($result, &$arr, $fetchmode, $rownum = null)
     {
         if ($rownum === null) {
-            $rownum = $this->res_row[(int)$result]++;
+            $rownum = $this->res_row[spl_object_hash($result)]++;
         }
         if ($fetchmode & DB_FETCHMODE_ASSOC) {
             $arr = @dbase_get_record_with_names($this->connection, $rownum);

--- a/DB/pgsql.php
+++ b/DB/pgsql.php
@@ -355,12 +355,12 @@ class DB_pgsql extends DB_common
         } elseif (preg_match('/^\s*\(*\s*(SELECT|EXPLAIN|FETCH|SHOW|WITH)\s/si',
                              $query))
         {
-            $this->row[(int)$result] = 0; // reset the row counter.
+            $this->row[spl_object_hash($result)] = 0; // reset the row counter.
             $numrows = $this->numRows($result);
             if (is_object($numrows)) {
                 return $numrows;
             }
-            $this->_num_rows[(int)$result] = $numrows;
+            $this->_num_rows[spl_object_hash($result)] = $numrows;
             $this->affected = 0;
             return $result;
         } else {
@@ -411,7 +411,7 @@ class DB_pgsql extends DB_common
      */
     function fetchInto($result, &$arr, $fetchmode, $rownum = null)
     {
-        $result_int = (int)$result;
+        $result_int = spl_object_hash($result);
         $rownum = ($rownum !== null) ? $rownum : $this->row[$result_int];
         if ($rownum >= $this->_num_rows[$result_int]) {
             return null;
@@ -455,9 +455,9 @@ class DB_pgsql extends DB_common
      */
     function freeResult($result)
     {
-        if (is_resource($result)) {
-            unset($this->row[(int)$result]);
-            unset($this->_num_rows[(int)$result]);
+        if (is_resource($id) || is_a($result, 'PgSql\\Result')) {
+            unset($this->row[spl_object_hash($result)]);
+            unset($this->_num_rows[spl_object_hash($result)]);
             $this->affected = 0;
             return @pg_free_result($result);
         }
@@ -905,7 +905,7 @@ class DB_pgsql extends DB_common
             $got_string = false;
         }
 
-        if (!is_resource($id)) {
+        if (!(is_resource($id)||is_a($result, 'PgSql\\Result'))) {
             return $this->pgsqlRaiseError(DB_ERROR_NEED_MORE_DATA);
         }
 

--- a/DB/pgsql.php
+++ b/DB/pgsql.php
@@ -411,9 +411,9 @@ class DB_pgsql extends DB_common
      */
     function fetchInto($result, &$arr, $fetchmode, $rownum = null)
     {
-        $result_int = spl_object_hash($result);
-        $rownum = ($rownum !== null) ? $rownum : $this->row[$result_int];
-        if ($rownum >= $this->_num_rows[$result_int]) {
+        $result_hash = spl_object_hash($result);
+        $rownum = ($rownum !== null) ? $rownum : $this->row[$result_hash];
+        if ($rownum >= $this->_num_rows[$result_hash]) {
             return null;
         }
         if ($fetchmode & DB_FETCHMODE_ASSOC) {
@@ -433,7 +433,7 @@ class DB_pgsql extends DB_common
         if ($this->options['portability'] & DB_PORTABILITY_NULL_TO_EMPTY) {
             $this->_convertNullArrayValuesToEmpty($arr);
         }
-        $this->row[$result_int] = ++$rownum;
+        $this->row[$result_hash] = ++$rownum;
         return DB_OK;
     }
 


### PR DESCRIPTION
pgsql result resource is deprecated from PHP 8.1. To avoid (int)$result raise warning, converted to spl_object_hash($result)(PHP>=5.2,7,8) instead.

spl_object_id returning int is more similar to (int)$result, but only in PHP>=7.2.0,8.